### PR TITLE
Draft: Decrease shovel mechanic required hits for whitelisted members

### DIFF
--- a/client/functions/tools/fn_operate_shovel.sqf
+++ b/client/functions/tools/fn_operate_shovel.sqf
@@ -26,15 +26,15 @@ private _currentTeam = player getVariable ["vn_mf_db_player_group", "MikeForce"]
 // player should have been validated as a whitelist member when joining the group
 // so no need to check whitelist again here
 
-if !(_currentTeam in ["MikeForce", "GreenHornets", "ACAV", "SpikeTeam"]) then
+if (_currentTeam in ["MikeForce", "GreenHornets", "ACAV", "SpikeTeam"]) then
 {
-    // 0.4 ==> 3x shovel hits to build up a structure
-    ["building_on_hit", [_building, 0.4]] call para_c_fnc_call_on_server;
+    // 0.2 ==> 5x shovel hits to build up a structure (default vanilla Mike Force setting)
+    ["building_on_hit", [_building, 0.2]] call para_c_fnc_call_on_server;
 } 
 else 
 {
-    // 0.2 ==> 5x shovel hits to build up a structure (the default vanilla Mike Force setting)
-    ["building_on_hit", [_building, 0.2]] call para_c_fnc_call_on_server;
+    // 0.4 ==> 3x shovel hits to build up a structure
+    ["building_on_hit", [_building, 0.4]] call para_c_fnc_call_on_server;
 };
 
 // without this the above function may get called about 7 times (see fn_operate_hammer.sqf)

--- a/client/functions/tools/fn_operate_shovel.sqf
+++ b/client/functions/tools/fn_operate_shovel.sqf
@@ -1,6 +1,6 @@
 /*
     File: fn_operate_shovel.sqf
-    Author:  Savage Game Design
+    Author:  Savage Game Design // John The GI / DJ Dijksterhuis
     Public: Yes
     
     Description:
@@ -18,6 +18,17 @@
 
 params ["_hitObject"];
 // systemchat "SHOVEL";
+
 private _building = _hitObject getVariable ["para_g_building", objNull];
-["building_on_hit", [_building, 0.2]] call para_c_fnc_call_on_server;
+private _currentTeam = player getVariable ["vn_mf_db_player_group", "MikeForce"];
+
+if !(_currentTeam in ["MikeForce", "GreenHornets", "ACAV", "SpikeTeam"]) then
+{
+	["building_on_hit", [_building, 0.4]] call para_c_fnc_call_on_server;
+} 
+else 
+{
+    ["building_on_hit", [_building, 0.2]] call para_c_fnc_call_on_server;
+};
+
 false

--- a/client/functions/tools/fn_operate_shovel.sqf
+++ b/client/functions/tools/fn_operate_shovel.sqf
@@ -1,6 +1,7 @@
 /*
     File: fn_operate_shovel.sqf
-    Author:  Savage Game Design // John The GI / DJ Dijksterhuis
+    Author:  Savage Game Design
+	Modified: John The GI / DJ Dijksterhuis
     Public: Yes
     
     Description:

--- a/client/functions/tools/fn_operate_shovel.sqf
+++ b/client/functions/tools/fn_operate_shovel.sqf
@@ -36,4 +36,5 @@ else
     ["building_on_hit", [_building, 0.2]] call para_c_fnc_call_on_server;
 };
 
+// without this the above function may get called about 7 times (see fn_operate_hammer.sqf)
 false

--- a/client/functions/tools/fn_operate_shovel.sqf
+++ b/client/functions/tools/fn_operate_shovel.sqf
@@ -1,7 +1,7 @@
 /*
     File: fn_operate_shovel.sqf
     Author:  Savage Game Design
-	Modified: John The GI / DJ Dijksterhuis
+    Modified: John The GI / DJ Dijksterhuis
     Public: Yes
     
     Description:

--- a/client/functions/tools/fn_operate_shovel.sqf
+++ b/client/functions/tools/fn_operate_shovel.sqf
@@ -27,12 +27,12 @@ private _currentTeam = player getVariable ["vn_mf_db_player_group", "MikeForce"]
 
 if !(_currentTeam in ["MikeForce", "GreenHornets", "ACAV", "SpikeTeam"]) then
 {
-	// 0.4 ==> 3x shovel hits to build up a structure
-	["building_on_hit", [_building, 0.4]] call para_c_fnc_call_on_server;
+    // 0.4 ==> 3x shovel hits to build up a structure
+    ["building_on_hit", [_building, 0.4]] call para_c_fnc_call_on_server;
 } 
 else 
 {
-	// 0.2 ==> 5x shovel hits to build up a structure (the default vanilla Mike Force setting)
+    // 0.2 ==> 5x shovel hits to build up a structure (the default vanilla Mike Force setting)
     ["building_on_hit", [_building, 0.2]] call para_c_fnc_call_on_server;
 };
 

--- a/client/functions/tools/fn_operate_shovel.sqf
+++ b/client/functions/tools/fn_operate_shovel.sqf
@@ -22,12 +22,17 @@ params ["_hitObject"];
 private _building = _hitObject getVariable ["para_g_building", objNull];
 private _currentTeam = player getVariable ["vn_mf_db_player_group", "MikeForce"];
 
+// player should have been validated as a whitelist member when joining the group
+// so no need to check whitelist again here
+
 if !(_currentTeam in ["MikeForce", "GreenHornets", "ACAV", "SpikeTeam"]) then
 {
+	// 0.4 ==> 3x shovel hits to build up a structure
 	["building_on_hit", [_building, 0.4]] call para_c_fnc_call_on_server;
 } 
 else 
 {
+	// 0.2 ==> 5x shovel hits to build up a structure (the default vanilla Mike Force setting)
     ["building_on_hit", [_building, 0.2]] call para_c_fnc_call_on_server;
 };
 


### PR DESCRIPTION
As discussed in Discord, change WLU unit shovel hits required to complete a structure build to 3, while keeping default setting of 5 for public players.