### PR TITLE
Draft: Change hammer mechanic hits

### DIFF
--- a/client/functions/tools/fn_operate_hammer.sqf
+++ b/client/functions/tools/fn_operate_hammer.sqf
@@ -1,10 +1,13 @@
 /*
     File: fn_operate_hammer.sqf
     Author:  Savage Game Design
+    Modified: DJ Dijksterhuis
     Public: Yes
     
     Description:
         Executes "Hammer" behaviour for building.
+        
+        NOTE: Vanilla Mike Force resource depletion rate is -0.5.
     
     Parameter(s):
         _hitObject object to be deconstructed
@@ -16,9 +19,25 @@
         [_thingToWhack] call para_c_fnc_operate_hammer
 */
 
-
 params ["_hitObject"];
+// systemchat "HAMMER";
+
 private _building = _hitObject getVariable ["para_g_building", objNull];
-["building_on_hit", [_building, -0.5]] call para_c_fnc_call_on_server;
-false; //without this the above function gets called about 7 times
-// systemChat "WRENCH";
+private _currentTeam = player getVariable ["vn_mf_db_player_group", "MikeForce"];
+
+// player should have been validated as a whitelist member when joining the group
+// so no need to check whitelist again here
+
+if (_currentTeam in ["MikeForce", "GreenHornets", "ACAV", "SpikeTeam"]) then
+{
+    // 0.2 ==> 5x hammer hits to destroy a structure
+    ["building_on_hit", [_building, -0.2]] call para_c_fnc_call_on_server;
+} 
+else 
+{
+    // 0.4 ==> 3x hammer hits to destroy up a structure
+    ["building_on_hit", [_building, -0.4]] call para_c_fnc_call_on_server;
+};
+
+// without this the above function may get called about 7 times
+false

--- a/client/functions/tools/fn_operate_hammer.sqf
+++ b/client/functions/tools/fn_operate_hammer.sqf
@@ -35,7 +35,7 @@ if (_currentTeam in ["MikeForce", "GreenHornets", "ACAV", "SpikeTeam"]) then
 } 
 else 
 {
-    // 0.4 ==> 3x hammer hits to destroy up a structure
+    // 0.4 ==> 3x hammer hits to destroy a structure
     ["building_on_hit", [_building, -0.4]] call para_c_fnc_call_on_server;
 };
 


### PR DESCRIPTION
As proposed by John in Discord. Unclear if this has sign off, hence the `Draft:` status.

Change WLU unit hammer hits required to be the inverse of shovel hits required (see PR #4).

This moves BN away from the default SGD setting of `-0.5`.