### PR TITLE
Lookup team traits config setting to determine building rate for player.

### DIFF
--- a/client/functions/tools/fn_operate_hammer.sqf
+++ b/client/functions/tools/fn_operate_hammer.sqf
@@ -1,6 +1,7 @@
 /*
     File: fn_operate_hammer.sqf
     Author:  Savage Game Design
+    Modified: DJ Dijksterhuis
     Public: Yes
     
     Description:
@@ -18,7 +19,18 @@
 
 
 params ["_hitObject"];
+// systemchat "HAMMER";
+
 private _building = _hitObject getVariable ["para_g_building", objNull];
-["building_on_hit", [_building, -0.5]] call para_c_fnc_call_on_server;
-false; //without this the above function gets called about 7 times
-// systemChat "WRENCH";
+
+// default build rate  5x shovel hits
+private _buildRate = 0.2;
+
+// does the boolean rate modifier trait exists on the player's team
+// if so, grant them a buffed build rate of 3x shovel hits
+// (defined in mike-force/mission/config/subconfigs/teams.hpp)
+
+if (player getUnitTrait "increasedBuildRate") then {_buildRate = 0.5};
+
+["building_on_hit", [_building, -_buildRate]] call para_c_fnc_call_on_server;
+

--- a/client/functions/tools/fn_operate_hammer.sqf
+++ b/client/functions/tools/fn_operate_hammer.sqf
@@ -23,11 +23,11 @@ params ["_hitObject"];
 
 private _building = _hitObject getVariable ["para_g_building", objNull];
 
-// default build rate  5x shovel hits
+// default build rate 5x hammer hits to tear down to 0%
 private _buildRate = 0.2;
 
 // does the boolean rate modifier trait exists on the player's team
-// if so, grant them a buffed build rate of 3x shovel hits
+// if so, grant them a buffed teardown rate of 3x hammer hits to fully destroy
 // (defined in mike-force/mission/config/subconfigs/teams.hpp)
 
 if (player getUnitTrait "increasedBuildRate") then {_buildRate = 0.5};

--- a/client/functions/tools/fn_operate_shovel.sqf
+++ b/client/functions/tools/fn_operate_shovel.sqf
@@ -1,6 +1,7 @@
 /*
     File: fn_operate_shovel.sqf
     Author:  Savage Game Design
+    Modified: "DJ" Dijksterhuis
     Public: Yes
     
     Description:
@@ -18,6 +19,18 @@
 
 params ["_hitObject"];
 // systemchat "SHOVEL";
+
 private _building = _hitObject getVariable ["para_g_building", objNull];
-["building_on_hit", [_building, 0.2]] call para_c_fnc_call_on_server;
+
+// default build rate  5x shovel hits
+private _buildRate = 0.2;
+
+// does the boolean rate modifier trait exists on the player's team 
+// if so, grant them a buffed build rate of 3x shovel hits
+// (defined in mike-force/mission/config/subconfigs/teams.hpp)
+
+if (player getUnitTrait "increasedBuildRate") then {_buildRate = 0.4};
+
+["building_on_hit", [_building, _buildRate]] call para_c_fnc_call_on_server;
+    
 false


### PR DESCRIPTION
Related to https://github.com/Bro-Nation/Mike-Force/pull/88

Sets the default build rate to `0.2` i.e. 5x shovel hits.

If the player's team (unit) has the `increasedBuildRate` custom trait set `true` then the build rate is modified to a buffed setting of `0.4` i.e. 3x shovel hits.

This means we do not have to directly reference team names over in Paradigm, which has no knowledge of Mike Force specific teams.

custom unit traits can only be boolean values, so not possible to do different rates per unit (possibly a good thing!).

Also makes it possible to expand the same or a similar rate buff to other actions like the hammer, wrench and axe/machete in the future (not in scope yet).

e.g. 

```
increasedFoliageRate = true;
increasedRepairRate = true,
```