### PR TITLE
Tweak valid AI spawn positions to exclude water terrain (rivers etc.)

### DIFF
--- a/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
+++ b/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
@@ -1,12 +1,39 @@
 /*
 	File: fn_spawning_find_valid_position_tracer.sqf
 	Author:  Savage Game Design
+	Modified: @dijksterhuis
 	Public: Yes
 	
 	Description:
 		Calculates a valid location to spawn at
-		Works by firing a 'tracer' from some distance away from a specific direction, which stops when it gets near to the target pos, or gets too close to a blocking unit.
+		Works by firing a 'tracer' from some distance away from a specific direction,
+		which stops when it gets near to the target pos, or gets too close to a blocking unit.
+
+		@dijksterhuis:
+
+		A "valid" location is defined is either:
+
+		- no playable units within 200m of the current point on the line
+		- no playable units can see the point on the line (blocked by trees etc.)
+
+		We've modified this to include a check which marks points where the terrain
+		surface is water (rivers, sea etc.) as invalid.
+
+		example line projection
+
+		x---x---x---x---x---x---x---x---x---x---x---o---o---o---x---I--------
 	
+		- 'x' marks are valid terrain positions (not surface water) and there
+		are no playable units nearby that might see the AI spawning in
+
+		- 'o' marks are not valid terrain positions (surface water) so we skip them
+
+		- The 'I' mark is where the search stops because it has detected playeable
+		units nearby.
+
+		The AI will then spawn in on the PREVIOUS valid position, i.e. the preceeding 'x'
+
+
 	Parameter(s):
 		_tracerEndPos - End position [Position]
 		_blockingUnits - Units that prevent spawning near them [Array, defaults to <playableUnits>]
@@ -46,28 +73,55 @@ private _index = 0;
 while {true} do {
 	_index = _index + 1;
 
+	// find the next point on the line
 	private _stepSize = ((_tracerPosition distance2D _tracerEndPos) / 10) max 100;
-	_lastTracerPosition = _tracerPosition;
-	_tracerPosition = _tracerPosition getPos [_stepSize, _attackDir];
+	private _newTracerPosition = _tracerPosition getPos [_stepSize, _attackDir];
 
-	//Places debug markers on the map when tracers are fired.
-	if (!isNil "debugAttackTracer") then {
-		private _mark = createMarker ["Tracer" + str diag_tickTime + str _index, _tracerPosition];
-		_mark setMarkerType "mil_dot";
-		_mark setMarkerColor "ColorPink";
-		tracerMarkers pushBack _mark;
+	// determine if the point on the line is valid according to the terrain
+	if (surfaceIsWater _newTracerPosition) then {
+
+		// invalid terrain, ignore this spawn position to mitigate AI spawning in water
+		_lastTracerPosition = _lastTracerPosition;
+
+		//Places debug markers on the map when tracers are fired.
+		if (!isNil "debugAttackTracer") then {
+			private _mark = createMarker ["TracerWater" + str diag_tickTime + str _index, _newTracerPosition];
+			_mark setMarkerType "mil_dot";
+			_mark setMarkerColor "ColorBlue";
+			tracerMarkers pushBack _mark;
+		};
+
+	} else {
+
+		// valid terrain, update the last known good spawn position
+		_lastTracerPosition = _tracerPosition;
+
+		//Places debug markers on the map when tracers are fired.
+		if (!isNil "debugAttackTracer") then {
+			private _mark = createMarker ["Tracer" + str diag_tickTime + str _index, _newTracerPosition];
+			_mark setMarkerType "mil_dot";
+			_mark setMarkerColor "ColorPink";
+			tracerMarkers pushBack _mark;
+		};
 	};
+
+	// now we inspect the point based on player distributions.
+	_tracerPosition = _newTracerPosition;
 
 	private _positionIsValid = true;
 	private _unitsNearNewPosition = _blockingUnits inAreaArray [_tracerPosition, _softBlockRadius, _softBlockRadius, 0, false];
 
+	// players are nearby
 	if !(_unitsNearNewPosition isEqualTo []) then {
+
 		//Check if any units are within the hard block radius - squads should *never* spawn in this radius
 		private _hardBlockUnits = _blockingUnits inAreaArray [_tracerPosition, _hardBlockRadius, _hardBlockRadius, 0, false];
 		if !(_hardBlockUnits isEqualTo []) exitWith {
 			_positionIsValid = false;
 			_stoppedOnTarget = _hardBlockUnits select 0;
 		};
+
+		//Check if any units are within the soft block radius - do not spawn squads if players can see them spawn in.
 		private _unitWithVisibilityIndex = _unitsNearNewPosition findIf {lineIntersectsSurfaces [eyePos _x, AGLtoASL _tracerPosition, _x] isEqualTo []};
 		if (_unitWithVisibilityIndex > -1) then { 
 			_positionIsValid = false; 
@@ -84,14 +138,18 @@ while {true} do {
 		};
 	};
 
-	//If we reach the destination, we can spawn at the target location without an issue
+	// @dijksterhuis: If we are very close to the end of the projected line
+	// then we need to start spawning in AI at the last known good position.
+	// this means AI spawn one line step further away from the objective,
+	// but this is necessary to avoid AI units spawning at water positions
+	// when setting _finalPosition = _tracerPosition
 	if (_tracerPosition distance2D _tracerEndPos < _stepSize) exitWith {
-		_finalPosition = _tracerEndPos;
+		_finalPosition = _lastTracerPosition;
 	};
 };
 
 if (!isNil "debugAttackTracer") then {
-	private _mark = createMarker ["TracerFinal" + str time, _tracerPosition];
+	private _mark = createMarker ["TracerFinal" + str time, _finalPosition];
 	_mark setMarkerType "mil_dot";
 	_mark setMarkerColor "ColorRed";
 	tracerMarkers pushBack _mark;

--- a/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
+++ b/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
@@ -82,24 +82,28 @@ while {true} do {
 
 		// invalid terrain, ignore this spawn position to mitigate AI spawning in water
 		_lastValidTracerPosition = _lastValidTracerPosition;
-		private _debugMarkerColour = "ColorBlue";
+
+		//Places debug markers on the map when tracers are fired.
+		if (!isNil "debugAttackTracer") then {
+			private _mark = createMarker ["TracerWater" + str diag_tickTime + str _index, _newTracerPosition];
+			_mark setMarkerType "mil_dot";
+			_mark setMarkerColor "ColorBlue";
+			tracerMarkers pushBack _mark;
+		};
 
 	} else {
 
 		// valid terrain, update the last known good spawn position
 		_lastValidTracerPosition = _tracerPosition;
-		private _debugMarkerColour = "ColorPink";
 
+		//Places debug markers on the map when tracers are fired.
+		if (!isNil "debugAttackTracer") then {
+			private _mark = createMarker ["Tracer" + str diag_tickTime + str _index, _newTracerPosition];
+			_mark setMarkerType "mil_dot";
+			_mark setMarkerColor "ColorPink";
+			tracerMarkers pushBack _mark;
+		};
 	};
-
-	//Places debug markers on the map when tracers are fired.
-	if (!isNil "debugAttackTracer") then {
-		private _mark = createMarker ["Tracer" + str diag_tickTime + str _index, _newTracerPosition];
-		_mark setMarkerType "mil_dot";
-		_mark setMarkerColor _debugMarkerColour;
-		tracerMarkers pushBack _mark;
-	};
-
 
 	// now we inspect the point based on player distributions.
 	_tracerPosition = _newTracerPosition;

--- a/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
+++ b/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
@@ -65,6 +65,8 @@ private _finalPosition = _tracerStart;
 //Unit that caused the tracer to stop.
 private _stoppedOnTarget = objNull;
 
+debugAttackTracer = true;
+
 if (!isNil "debugAttackTracer" && isNil "tracerMarkers") then {
 	tracerMarkers = [];
 };
@@ -83,7 +85,7 @@ while {true} do {
 		// invalid terrain, ignore this spawn position to mitigate AI spawning in water
 		_lastValidTracerPosition = _lastValidTracerPosition;
 
-		//Places debug markers on the map when tracers are fired.
+		// Places debug markers on the map when tracers are fired.
 		if (!isNil "debugAttackTracer") then {
 			private _mark = createMarker ["TracerWater" + str diag_tickTime + str _index, _newTracerPosition];
 			_mark setMarkerType "mil_dot";
@@ -131,11 +133,7 @@ while {true} do {
 
 	//If we find a unit, we exit and set the last valid position + which target stopped us.
 	if (!_positionIsValid) exitWith {
-		if (_tracerPosition isEqualTo _tracerStart) then {
-			_finalPosition = [];
-		} else {
-			_finalPosition = _lastValidTracerPosition;
-		};
+		_finalPosition = _lastValidTracerPosition;
 	};
 
 	// @dijksterhuis: If we are very close to the end of the projected line
@@ -144,7 +142,7 @@ while {true} do {
 	// but this is necessary to avoid AI units spawning at water positions
 	// when setting _finalPosition = _tracerPosition
 	if (_tracerPosition distance2D _tracerEndPos < _stepSize) exitWith {
-		_finalPosition = _lastValidTracerPosition;
+		_finalPosition = _tracerPosition;
 	};
 };
 
@@ -153,6 +151,10 @@ if (!isNil "debugAttackTracer") then {
 	_mark setMarkerType "mil_dot";
 	_mark setMarkerColor "ColorRed";
 	tracerMarkers pushBack _mark;
+};
+
+if (_finalPosition isEqualTo _tracerStart) then {
+	_finalPosition = [];
 };
 
 [_finalPosition, _stoppedOnTarget]

--- a/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
+++ b/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
@@ -57,7 +57,7 @@ private _hardBlockRadius = 200;
 //Adjust the tracer to end _minDistance away.
 _tracerEndPos = _tracerEndPos getPos [_minDistance, _attackDir + 180];
 private _tracerStart = _tracerEndPos getPos [1500, _attackDir + 180];
-private _lastTracerPosition = _tracerStart;
+private _lastValidTracerPosition = _tracerStart;
 private _tracerPosition = _tracerStart;
 
 //The valid position to spawn at
@@ -81,7 +81,7 @@ while {true} do {
 	if (surfaceIsWater _newTracerPosition) then {
 
 		// invalid terrain, ignore this spawn position to mitigate AI spawning in water
-		_lastTracerPosition = _lastTracerPosition;
+		_lastValidTracerPosition = _lastValidTracerPosition;
 
 		//Places debug markers on the map when tracers are fired.
 		if (!isNil "debugAttackTracer") then {
@@ -94,7 +94,7 @@ while {true} do {
 	} else {
 
 		// valid terrain, update the last known good spawn position
-		_lastTracerPosition = _tracerPosition;
+		_lastValidTracerPosition = _tracerPosition;
 
 		//Places debug markers on the map when tracers are fired.
 		if (!isNil "debugAttackTracer") then {
@@ -134,7 +134,7 @@ while {true} do {
 		if (_tracerPosition isEqualTo _tracerStart) then {
 			_finalPosition = [];
 		} else {
-			_finalPosition = _lastTracerPosition;
+			_finalPosition = _lastValidTracerPosition;
 		};
 	};
 
@@ -143,8 +143,8 @@ while {true} do {
 	// this means AI spawn one line step further away from the objective,
 	// but this is necessary to avoid AI units spawning at water positions
 	// when setting _finalPosition = _tracerPosition
-	if (_tracerPosition distance2D _tracerEndPos < _stepSize) exitWith {
-		_finalPosition = _lastTracerPosition;
+	if (_tracerPosition distance2D _tracerEndPos < (_stepSize * 2)) exitWith {
+		_finalPosition = _lastValidTracerPosition;
 	};
 };
 

--- a/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
+++ b/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
@@ -143,7 +143,7 @@ while {true} do {
 	// this means AI spawn one line step further away from the objective,
 	// but this is necessary to avoid AI units spawning at water positions
 	// when setting _finalPosition = _tracerPosition
-	if (_tracerPosition distance2D _tracerEndPos < (_stepSize * 2)) exitWith {
+	if (_tracerPosition distance2D _tracerEndPos < _stepSize) exitWith {
 		_finalPosition = _lastValidTracerPosition;
 	};
 };

--- a/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
+++ b/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
@@ -82,28 +82,24 @@ while {true} do {
 
 		// invalid terrain, ignore this spawn position to mitigate AI spawning in water
 		_lastValidTracerPosition = _lastValidTracerPosition;
-
-		//Places debug markers on the map when tracers are fired.
-		if (!isNil "debugAttackTracer") then {
-			private _mark = createMarker ["TracerWater" + str diag_tickTime + str _index, _newTracerPosition];
-			_mark setMarkerType "mil_dot";
-			_mark setMarkerColor "ColorBlue";
-			tracerMarkers pushBack _mark;
-		};
+		private _debugMarkerColour = "ColorBlue";
 
 	} else {
 
 		// valid terrain, update the last known good spawn position
 		_lastValidTracerPosition = _tracerPosition;
+		private _debugMarkerColour = "ColorPink";
 
-		//Places debug markers on the map when tracers are fired.
-		if (!isNil "debugAttackTracer") then {
-			private _mark = createMarker ["Tracer" + str diag_tickTime + str _index, _newTracerPosition];
-			_mark setMarkerType "mil_dot";
-			_mark setMarkerColor "ColorPink";
-			tracerMarkers pushBack _mark;
-		};
 	};
+
+	//Places debug markers on the map when tracers are fired.
+	if (!isNil "debugAttackTracer") then {
+		private _mark = createMarker ["Tracer" + str diag_tickTime + str _index, _newTracerPosition];
+		_mark setMarkerType "mil_dot";
+		_mark setMarkerColor _debugMarkerColour;
+		tracerMarkers pushBack _mark;
+	};
+
 
 	// now we inspect the point based on player distributions.
 	_tracerPosition = _newTracerPosition;

--- a/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
+++ b/global/functions/spawning/fn_spawning_find_valid_position_tracer.sqf
@@ -65,8 +65,6 @@ private _finalPosition = _tracerStart;
 //Unit that caused the tracer to stop.
 private _stoppedOnTarget = objNull;
 
-debugAttackTracer = true;
-
 if (!isNil "debugAttackTracer" && isNil "tracerMarkers") then {
 	tracerMarkers = [];
 };


### PR DESCRIPTION
Added a check to ignore points on the projected line which are water based terrain. Also added some commentary to better explain how this script works.

I've had to tweak the algorithm slightly to make this work in it's current state. 

Instead of spawning AI on the final tracer point when close enough to the end point of the tracer line, the AI will now spawn on the previous point it found to be valid (no water). Otherwise the water terrain check can be ignored. Means AI may spawn anywhere up to 100m further away from where they would normally in certain conditions. See the last `if () exitWith {}` line [here](https://github.com/Bro-Nation/Paradigm/pull/10/files#diff-5db12d0f69447dc3c23b6ed22653e721d756345aa7010f76abf391ff2eea3331R146-R148)

This ^ does not apply when players are detected nearby. Previously it would take the last known good position in that case, which is kept in this change.
