### PR TITLE
[FIXUP] "crew" AI would never move to newly assigned objectives

### DIFF
--- a/server/functions/ai_objectives/fn_ai_obj_request_crew.sqf
+++ b/server/functions/ai_objectives/fn_ai_obj_request_crew.sqf
@@ -60,4 +60,21 @@ _objective setVariable ["onTick", {
 	_objective setPos getPos (_objective getVariable "vehicle");
 }];
 
+/*
+we cannot retask AI if they are on a static weapon as they are unable to move.
+so force them out of the static and then the AI system can reassign them.
+*/
+_objective setVariable ["onDeactivation", {
+	params ["_objective"];
+	private _groups = _objective getVariable ["assignedGroups", []];
+	{
+		private _g = _x;
+		{
+			If(_x == (vehicle _x)) then {
+				moveOut _x;
+			};
+		} forEach (units _g);
+	} forEach _groups;
+}];
+
 _objective

--- a/server/functions/ai_objectives/fn_ai_obj_request_crew.sqf
+++ b/server/functions/ai_objectives/fn_ai_obj_request_crew.sqf
@@ -66,15 +66,9 @@ so force them out of the static and then the AI system can reassign them.
 */
 _objective setVariable ["onDeactivation", {
 	params ["_objective"];
-	private _groups = _objective getVariable ["assignedGroups", []];
-	{
-		private _g = _x;
-		{
-			If(_x == (vehicle _x)) then {
-				moveOut _x;
-			};
-		} forEach (units _g);
-	} forEach _groups;
+	_objective getVariable ["assignedGroups", []] apply {
+		(units _x) apply {if(_x == (vehicle _x)) then {moveOut _x}};
+	};
 }];
 
 _objective


### PR DESCRIPTION
AI are unable to move anywhere once they have mounted a static weapon at site X. 

If the AI subsytem determines site Y is now higher priority (needs AI), and site Y is within the reallocation range (600m), the subsystem will deallocate the AI from site X and give them a move order to site Y.

But "crew" AI are in static weapons, and can't move anywhere!

So when a "crew" objective is deactivated we need to `moveOut` any AI on the statics so they are free to move somewhere else.

**NOTE** -- for the below screenshots I increased the reallocation range to 1300m to make sure I could demonstrate the change working.

## BEFORE

### AI tasked with a move order to higher priority site

![20230730002445_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/353b0673-ebc6-474a-817c-bc3ccee70729)

### AI cannot move as they are in a static

![20230730002449_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/f5b80d0d-684c-48f0-b7c9-396b600b9e9c)

## AFTER

### AI on the western most sites

![20230729235631_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/6ec84c74-d4aa-4049-abfd-a284e7fd21ee)

### AI are all occupying all the statics (camp and an arty site I believe)

![20230729235627_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/39194e22-c0fc-4600-a830-9e291137ebc6)

![20230729235622_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/8f1beead-a6b0-46c2-aea1-bb5f2301bade)

### initial retasking after player moves (changes AI objective priority)

I move to the other side of the AO, the AI on the statics at the southern site are re-tasked with move orders to new high priority objective.

![20230729235722_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/61676fbb-4cb7-48b4-a8f7-9febac1e35c5)

### AI being to dismount and move to new objective

Note that it can take 5-15 seconds for all the AI to dismount and start moving away.

![20230729235720_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/7abf334d-133a-4a36-b588-d9087a65cd69)

### I move a further north so AI on statics at the western most site are now retasked 

![20230729235735_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/0d6beb4e-4a04-40e9-b5eb-387353c13052)

### AI demounting and moving to new objective.

![20230729235738_1](https://github.com/Bro-Nation/Paradigm/assets/11841332/33b86456-19a1-40ff-978e-9f9c6b6b8ff0)
