### PR TITLE
[TWEAK] Ignore certain players from AI objective spawning priority calculations.

### DIFF
--- a/server/functions/ai_objectives/fn_ai_obj_job.sqf
+++ b/server/functions/ai_objectives/fn_ai_obj_job.sqf
@@ -13,7 +13,13 @@
 	Example(s): none
 */
 
-private _allPlayers = allUnits select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")} && !(vehicle _x isKindOf "Plane") && !(speed vehicle _x > 300)};
+
+/*
+@dijksterhuis BN changes
+- [TWEAK] Not in vehicle travelling over 200 km/h (down from SGD upstream 300 km/h)
+- [ADD] Not dac cong (assumption that side east == dac cong)
+*/
+private _allPlayers = allUnits select {isPlayer _x && {!(_x isKindOf "HeadlessClient_F")} && !(vehicle _x isKindOf "Plane") && (speed vehicle _x < 200) && !(side _x == east)};
 
 //Groups of AI that are no longer in use by the system.
 //We can reuse these for other objectives later.


### PR DESCRIPTION
Part of efforts to buy back some AI count for bluefor.

- Dac Cong aren't fighting against the AI and shouldn't have AI assigned objectives for them.
- Helicopters flying relatively fast through an AO would trigger multiple AI spawning and de-spawning (under 300km/h only excludes jets)