### PR TITLE
[UPDATE] Don't wait to reinforce dead AI units in groups.

### DIFF
--- a/server/functions/ai_objectives/fn_ai_obj_job.sqf
+++ b/server/functions/ai_objectives/fn_ai_obj_job.sqf
@@ -191,7 +191,8 @@ private _assignedUnitFlex = 4;
 	call
 	{
 		//Don't need to do anything if we have enough units. Let's roughly define that as 50% dead for now.
-		if (_totalAliveUnits >= _desiredUnitCount * 0.5) exitWith {};
+		// @dijksterhuis -- modified to always reinforce to full strength
+		if (_totalAliveUnits >= _desiredUnitCount * 1) exitWith {};
 
 		private _reinforcementsNeeded = _desiredUnitCount - _totalAliveUnits;
 


### PR DESCRIPTION
Waiting for an AI group to become 50% depleted could take a while for another AI group to be assigned to the AI objective.

These new AI units also have to travel in from further away, so it's probably better we spawn them in earlier rather than later.
