### PR TITLE
[UPDATE] Reduce amout of log spam (Nx messages every 5 seconds).

### DIFF
--- a/server/functions/ai_objectives/fn_ai_obj_job.sqf
+++ b/server/functions/ai_objectives/fn_ai_obj_job.sqf
@@ -232,6 +232,7 @@ private _assignedUnitFlex = 4;
 			_unitsRemainingInGlobalPool
 			max 0;
 
+		/*
 		diag_log format [
 			"AI Obj %1 [%6]: Reinforcing with %2 units. Needed: %3, available: %4, global: %5",
 			_obj getVariable "id",
@@ -241,6 +242,7 @@ private _assignedUnitFlex = 4;
 			_unitsRemainingInGlobalPool,
 			_obj getVariable "type"
 		];
+		*/
 
 		[_obj, _unitsToSendCount] call para_s_fnc_ai_obj_reinforce;
 		_currentUnitCount = _currentUnitCount + _unitsToSendCount;


### PR DESCRIPTION
AI obj main runs every 5 seconds and this lists every single AI objective needing reinforcements in logs (which is very spammy because we're so starved of AI count, nothing can get reinforced).

Every other log message in this file is commented out for similar reasons.