### PR TITLE
AI Behaviour: AI will lay down / kneel when they're supposed to be angrily attacking a FOB.

### DIFF
--- a/global/functions/ai_behaviours/fn_behaviour_attack.sqf
+++ b/global/functions/ai_behaviours/fn_behaviour_attack.sqf
@@ -48,6 +48,11 @@ if (behaviour leader _group != "AWARE") then {
 	_group setBehaviour "AWARE";
 };
 
+// @dijksterhuis: The original SGD code allows AI to lay down, crawl, kneel, crouch etc.
+// When 'attacking' in Mike Force, the AI are usually supposed to be running at a bluefor FOB.
+// So going prone doesn't make much sense.
+// How are they going to get to the FOB if they're crawling all the way there!
+
 // [_group, "AUTO"] call para_g_fnc_behaviour_set_group_stance;
 [_group, "UP"] call para_g_fnc_behaviour_set_group_stance;
 

--- a/global/functions/ai_behaviours/fn_behaviour_attack.sqf
+++ b/global/functions/ai_behaviours/fn_behaviour_attack.sqf
@@ -48,7 +48,8 @@ if (behaviour leader _group != "AWARE") then {
 	_group setBehaviour "AWARE";
 };
 
-[_group, "AUTO"] call para_g_fnc_behaviour_set_group_stance;
+// [_group, "AUTO"] call para_g_fnc_behaviour_set_group_stance;
+[_group, "UP"] call para_g_fnc_behaviour_set_group_stance;
 
 
 //TODO - Make them flank when attacking


### PR DESCRIPTION
The original SGD code allows AI to lay down, crawl, kneel, crouch etc. (group stance mode 'AUTO')

When 'attacking' in Mike Force, the AI are usually supposed to be running at a bluefor FOB.

So going prone doesn't make much sense.

How are the AI going to get to the FOB if they're crawling all the way there!

---

Context: This was put together back when the Lambs AI mod was still on server and causing a wealth of issues with the AI. So it may not be needed quite as much anymore.