### PR TITLE
CleanUp: Add abandoned disassembled weapons to item cleanup job.

### DIFF
--- a/server/functions/cleanup/fn_cleanup_register_player.sqf
+++ b/server/functions/cleanup/fn_cleanup_register_player.sqf
@@ -25,4 +25,15 @@ if (para_s_cleanup_clean_placed_gear) then {
 			[_container, false, para_s_cleanup_placed_gear_cleanup_time] call para_s_fnc_cleanup_add_items;
 		};
 	}];
+
+	// disassembled weapons left alone for 30 minutes are probably abandoned in an old AO.
+	_player addEventHandler [
+		"WeaponDisassembled",
+		{
+			params ["_unit", "_primaryBag", "_secondaryBag"];
+
+			[_primaryBag, true, 30 * 60] call para_s_fnc_cleanup_add_items;
+			[_secondaryBag, true, 30 * 60] call para_s_fnc_cleanup_add_items;
+		};
+	];
 };


### PR DESCRIPTION
NOTE -- 'Abandoned' here means -- no players have been within 400m of the disassembled bags for the last 30 minutes! i.e. the bags are stranded in an old AO and no-one wants them.

'true' arg ==> check if players arenearby during clean up job
30 * 60 arg ==> leave them alone for 30 minutes.