### PR TITLE
Harass: Possible fix for AI appearing at main base (Pleiku etc.).

### DIFF
--- a/server/functions/ai_objectives/fn_ai_obj_request_pursuit.sqf
+++ b/server/functions/ai_objectives/fn_ai_obj_request_pursuit.sqf
@@ -46,7 +46,16 @@ _objective setVariable ["targets", _targets];
 _objective setVariable ["onTick", {
 	params ["_objective"];
 	private _lastTargetPos = getPos _objective;
-	private _targets = _objective getVariable "targets" inAreaArray [_lastTargetPos, para_s_ai_obj_pursuitRadius, para_s_ai_obj_pursuitRadius] select {alive _x};
+
+	/*
+	Filter out targets (players) that are not
+	- within specified radius of previous tracker team objective position
+	- alive
+	- outside blocked / no_harrass area markers (i.e. hanging around at the main base)
+	*/
+	private _targets = [
+		_objective getVariable "targets" inAreaArray [_lastTargetPos, para_s_ai_obj_pursuitRadius, para_s_ai_obj_pursuitRadius] select {alive _x}
+	] call para_interop_fnc_harass_filter_target_players;
 
 	//If we've lost the target, complete the pursuit.
 	if (_targets isEqualTo []) exitWith {


### PR DESCRIPTION
I think this issue is because a player is marked as harassable and has an AI objective assigned to them.

Then they move back to the main base, but they still have an existing AI objective assigned to them.

The AI objective is never cancelled when they move back to the main base etc.

So AI keep coming to attack them.