### PR TITLE
Harass: Prioritise tracking non-incapacitated players (reduce chance AI stationary on a incap players).

### DIFF
--- a/server/functions/ai_objectives/fn_ai_obj_request_pursuit.sqf
+++ b/server/functions/ai_objectives/fn_ai_obj_request_pursuit.sqf
@@ -56,7 +56,14 @@ _objective setVariable ["onTick", {
 		[_objective] call para_s_fnc_ai_obj_finish_objective;
 	};
 
-	private _target = _targets select 0;
+	// try to focus on a target that's not incapacitated with vn_revive.
+	// want to avoid AI standing around targets that are incapacitated
+	// while other targets nearby are active.
+	// TODO: patrol around or move away if no 'up' players?
+	private _target = _targets findIf {!(_x getVariable ["vn_revive_incapacitated", false])};
+	if (_target == -1) then {
+		_target = _targets select 0;
+	};
 	
 	//Update objective position to be on the target, so it stays active.
 	_objective setPos getPos _target;


### PR DESCRIPTION
I'm hoping this *should* reduce the time AI dumbly stand around on top of a player's body.

AI will try to find a target to follow that is not incapacitated. If none exists for this objective (player is lone wolf or whole team is incap'd), the AI will stick with the first target in their objective.
