### PR TITLE
Building: Add ability to rotate builds by 45 degrees

### DIFF
--- a/client/functions/basebuilding/fn_abort_building.sqf
+++ b/client/functions/basebuilding/fn_abort_building.sqf
@@ -34,4 +34,9 @@ if (!isNil "para_l_placing_click_handler") then {
 	para_l_placing_click_handler = nil;
 };
 
+if (!isNil "para_l_placing_keyrotate_handler") then {
+	(findDisplay 46) displayRemoveEventHandler ["MouseButtonUp", para_l_placing_keyrotate_handler];
+	para_l_placing_keyrotate_handler = nil;
+};
+
 false;

--- a/client/functions/basebuilding/fn_abort_building.sqf
+++ b/client/functions/basebuilding/fn_abort_building.sqf
@@ -35,7 +35,7 @@ if (!isNil "para_l_placing_click_handler") then {
 };
 
 if (!isNil "para_l_placing_keyrotate_handler") then {
-	(findDisplay 46) displayRemoveEventHandler ["MouseButtonUp", para_l_placing_keyrotate_handler];
+	(findDisplay 46) displayRemoveEventHandler ["KeyDown", para_l_placing_keyrotate_handler];
 	para_l_placing_keyrotate_handler = nil;
 };
 

--- a/client/functions/basebuilding/fn_place_object.sqf
+++ b/client/functions/basebuilding/fn_place_object.sqf
@@ -185,6 +185,21 @@ para_l_placing_click_handler = (findDisplay 46) displayAddEventHandler ["MouseBu
 	};
 }];
 
+// Adding key handler for rotation by 45 degrees (R key) 
+para_l_placing_keyrotate_handler = (findDisplay 46) displayAddEventHandler ["KeyDown", { 
+	params ["_displayorcontrol", "_keyCode"]; 
+	if (_keyCode in [0x13]) then { // 0x13 is the 'R' key 
+		para_l_placing_final_rotation = para_l_placing_final_rotation + 45; 
+		if (para_l_placing_final_rotation >= 360) then { 
+			para_l_placing_final_rotation = para_l_placing_final_rotation - 360; 
+		}; 
+		// Apply the new rotation to the object 
+		if (!isNull para_l_placing_object) then { 
+			para_l_placing_object setDir para_l_placing_final_rotation; 
+		}; 
+	}; 
+}];
+
 para_l_placing_mode = 0;
 para_l_placing_center_pos = [0,0,0];
 para_l_placing_last_player_dir = getDir player;

--- a/client/functions/basebuilding/fn_place_object.sqf
+++ b/client/functions/basebuilding/fn_place_object.sqf
@@ -188,15 +188,8 @@ para_l_placing_click_handler = (findDisplay 46) displayAddEventHandler ["MouseBu
 // Adding key handler for rotation by 45 degrees (R key) 
 para_l_placing_keyrotate_handler = (findDisplay 46) displayAddEventHandler ["KeyDown", { 
 	params ["_displayorcontrol", "_keyCode"]; 
-	if (_keyCode in [0x13]) then { // 0x13 is the 'R' key 
+	if (!scriptDone para_l_placing_script && _keyCode in [0x13]) then { // 0x13 is the 'R' key
 		para_l_placing_final_rotation = para_l_placing_final_rotation + 45; 
-		if (para_l_placing_final_rotation >= 360) then { 
-			para_l_placing_final_rotation = para_l_placing_final_rotation - 360; 
-		}; 
-		// Apply the new rotation to the object 
-		if (!isNull para_l_placing_object) then { 
-			para_l_placing_object setDir para_l_placing_final_rotation; 
-		}; 
 	}; 
 }];
 


### PR DESCRIPTION
Added the function to rotate buildings by 45 degrees with the R key whilst in "build mode" with an event handler. This should be helpful for most builders to keep constructions neat and tidy. No functions of LMB or RMB are affected.
## To do 
- [x] investigate why sometimes switches to 90 degree or refuses to rotate.
## Screenshots
![20240817172032_1](https://github.com/user-attachments/assets/ae58c75d-761c-4b7b-b50d-7fab3022049c)
![20240817171957_1](https://github.com/user-attachments/assets/0be8609c-9ada-4fc6-b820-eb7041cc9f23)
