### PR TITLE
Scheduler: Disable Debug logs (we have enough data now).

### DIFF
--- a/global/functions/scheduler/fn_scheduler_subsystem_init.sqf
+++ b/global/functions/scheduler/fn_scheduler_subsystem_init.sqf
@@ -24,4 +24,4 @@ call para_g_fnc_scheduler_start;
 0 spawn para_g_fnc_scheduler_monitor;
 
 // print debug logs
-debugScheduler = true;
+// debugScheduler = true;


### PR DESCRIPTION
I have about 3 GB of logs data stored in an S3 bucket. We're good for debug logs data now.