### PR TITLE
Cleanup: Remove dead AI units faster through a spawned hideBody command.

### DIFF
--- a/global/functions/create/fn_create_unit.sqf
+++ b/global/functions/create/fn_create_unit.sqf
@@ -38,8 +38,40 @@ _unit setSkill ["spotTime", 1];
 _unit setSkill ["aimingAccuracy", 0.10];
 
 _unit addEventHandler ["Killed", {
-	params ["_unit"];
+	params ["_unit", ""];
+
 	[_unit] call para_s_fnc_cleanup_add_items;
+
+	// if for some reason AI are not deleted immediately then hide them and then delete
+	// after circa one minute
+	// this is to stop bodies piling up and player held positions like FOBs, COPs etc.
+	// because players are nearby for long periods of time.
+
+	[_unit] spawn {
+		params ["_unit"];
+
+		// repeatedly check whether the unit was deleted by the clean up job
+		// before doing each step
+
+		private _unitIdx = para_s_cleanup_items_range_restricted findIf {_x isEqualTo _unit};
+		if (_unitIdx isEqualTo -1) exitWith {nil};
+
+		sleep 55;
+
+		_unitIdx = para_s_cleanup_items_range_restricted findIf {_x isEqualTo _unit};
+		if (_unitIdx isEqualTo -1) exitWith {nil};
+
+		hideBody _unit;
+		sleep 10;
+
+		_unitIdx = para_s_cleanup_items_range_restricted findIf {_x isEqualTo _unit};
+		if (_unitIdx isEqualTo -1) exitWith {nil};
+
+		// deleting the unit also deletes the dropped weapon holder.
+		deleteVehicle _unit;
+
+	};
+
 }];
 
 _unit

--- a/server/functions/cleanup/fn_cleanup_subsystem_init.sqf
+++ b/server/functions/cleanup/fn_cleanup_subsystem_init.sqf
@@ -39,6 +39,10 @@ para_s_cleanup_items_time_check = [];
 
 ["cleanup", {call para_s_fnc_cleanup_job}, [], 5] call para_g_fnc_scheduler_add_job;
 
+/*
+// disabled by @dijksterhuis as part of PR #39
+// see paradigm\global\functions\create\fn_create_unit.sqf
+
 if (para_s_cleanup_clean_dropped_gear) then {
 	addMissionEventHandler ["EntityKilled", {
 		params ["_unit"];
@@ -50,3 +54,4 @@ if (para_s_cleanup_clean_dropped_gear) then {
 		};
 	}];
 };
+*/


### PR DESCRIPTION
AI bodies keep getting piled up and not being despawned in the counterattack phase etc.

Paradigm checks whether players are near the objects being tracked for deletion, and will refuse to delete the objects if there are playes in the vicinity.

This change adds a spawned script which will hide any remaining AI bodies after 60 seconds and then delete them when out of view of players.

We can tweak the timer up / down as needed. One minute seemed to provide some balance for players wanting to pick up FAKs or weapons from dead AI -- you've got 60 seconds to grab some near gear.