### PR TITLE
Add invulnerable building feature and MP filter

### DIFF
--- a/client/functions/ui/building_menu/fn_buildingMenu_indexBuildings.sqf
+++ b/client/functions/ui/building_menu/fn_buildingMenu_indexBuildings.sqf
@@ -17,15 +17,26 @@
 private _config = missionConfigFile >> "gamemode" >> "buildables";
 private _buildables = "true" configClasses _config;
 private _playerSide = side player;
+private _isMilitaryPolice = player getVariable ["vn_mf_db_player_group", "MikeForce"] isEqualTo "MilitaryPolice";
+
 private _nvaBuildables = _buildables select { 
 	private _categories = getArray (_x >> "categories");
 	"nv" in _categories
+};
+
+private _mpBuildables = _buildables select {
+	private _categories = (getArray (_x >> "categories")) apply {toLower _x};
+	"mp" in _categories
 };
 
 if (_playerSide == east) then {
 	_buildables = _nvaBuildables;
 } else {
 	_buildables = _buildables - _nvaBuildables;
+};
+
+if !(_isMilitaryPolice) then {
+	_buildables = _buildables - _mpBuildables;
 };
 
 private _name = "";

--- a/server/configs/building_features.hpp
+++ b/server/configs/building_features.hpp
@@ -44,6 +44,11 @@ class CfgBuildingFeatures
 		onBuildingObjectsChanged = "para_s_fnc_bf_maintenance_on_building_objects_changed";
 	};
 
+	class invulnerable
+	{
+		onBuildingObjectsChanged = "para_s_fnc_bf_invulnerable_on_building_objects_changed";
+	};
+
 	class radio
 	{
 		onBuildingFunctional = "para_s_fnc_bf_radio_on_functional";

--- a/server/functions.hpp
+++ b/server/functions.hpp
@@ -92,6 +92,12 @@ class para_s
 		class bf_maintenance_repair_vehicle {};
 	};
 
+	class building_features_invulnerable
+	{
+		PARA_SERVER_PATH(\building_features\invulnerable);
+		class bf_invulnerable_on_building_objects_changed {};
+	};
+
 	class building_features_radio
 	{
 		PARA_SERVER_PATH(\building_features\radio);

--- a/server/functions/building_features/invulnerable/fn_bf_invulnerable_on_building_objects_changed.sqf
+++ b/server/functions/building_features/invulnerable/fn_bf_invulnerable_on_building_objects_changed.sqf
@@ -1,0 +1,24 @@
+/*
+    File: fn_bf_invulnerable_on_building_objects_changed.sqf
+    Author:  Savage Game Design
+    Public: No
+
+    Description:
+        Persists no-damage on all objects belonging to a building.
+
+    Parameter(s):
+        _building - Building whose objects have changed [NAMESPACE]
+        _newObjects - New objects attached to the building [ARRAY]
+
+    Returns:
+        None
+
+    Example(s):
+        See building features config
+*/
+
+params ["_building", "_newObjects"];
+
+{
+	[_x, false] call para_s_fnc_allow_damage_persistent;
+} forEach _newObjects;


### PR DESCRIPTION
Register an 'invulnerable' building feature and wire up server/client behavior. Adds CfgBuildingFeatures entry and functions.hpp registration, and implements para_s_fnc_bf_invulnerable_on_building_objects_changed which persists no-damage on newly attached building objects. Client UI updated to detect player 'MilitaryPolice' group and hide/build include items tagged with the "mp" category (case-insensitive) for non-MP players.