### PR TITLE
Exclude 'invulnerable' from building features

### DIFF
--- a/client/functions/ui/building_menu/fn_buildingMenu_indexCategories.sqf
+++ b/client/functions/ui/building_menu/fn_buildingMenu_indexCategories.sqf
@@ -67,7 +67,9 @@ if (isNil "para_c_buildingMenu_features") then
 	private _features = [];
 	{
 		{
-			_features pushBackUnique _x;
+			if (_x != "invulnerable") then {
+				_features pushBackUnique _x;
+			};
 		} forEach (_x select 5);
 	} forEach _allBuildables;
 	para_c_buildingMenu_features = _features;


### PR DESCRIPTION
Prevent the "invulnerable" flag from being added to the building menu features list. The loop now skips any feature equal to "invulnerable" so it won't appear in para_c_buildingMenu_features when indexing buildable items.